### PR TITLE
handle more gmail links within gmail-desktop

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@ export const appName = 'Gmail Desktop'
 // Keep in sync with `build.appId` in `package.json`
 export const appId = 'io.cheung.gmail-desktop'
 
-export const gmailUrl = 'https://mail.google.com/mail/u/0/'
+export const gmailUrl = 'https://mail.google.com/mail/u/'
 
 export const googleAccountsUrl = 'https://accounts.google.com'
 


### PR DESCRIPTION
- fix for 348, as well as other improvements for handling gmail links
- opens "View entire message" and print views
- downloads "download original" without browser
- even from child windows
- added context menu to child windows

I think this one will need a little more testing, as I am unsure how it works with multiple accounts
also I wasn't sure of the purpose of line 73 in [src/main/account-views/index.ts](https://github.com/timche/gmail-desktop/compare/develop...brendanmeyer:gmail-desktop:develop-fiximprove348#diff-a32e498a5eb123057c0bfbe8ffa749a35967eb9860f30e8cd30febd139f22826)