### PR TITLE
Mailto and Default Mail Client fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "gmail-desktop",
-  "version": "3.0.0-alpha.35",
+  "version": "3.0.0-alpha.37",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gmail-desktop",
-      "version": "3.0.0-alpha.35",
+      "version": "3.0.0-alpha.37",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/do-not-disturb": "^1.1.0"
+        "@sindresorhus/do-not-disturb": "^1.1.0",
+        "winreg": "^1.2.4"
       },
       "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -29461,6 +29462,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/winreg": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+      "integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA=="
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -52606,6 +52612,11 @@
       "requires": {
         "string-width": "^4.0.0"
       }
+    },
+    "winreg": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+      "integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/do-not-disturb": "^1.1.0",
-        "winreg": "^1.2.4"
+        "@sindresorhus/do-not-disturb": "^1.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -30,6 +29,7 @@
         "@types/lodash.debounce": "^4.0.6",
         "@types/node": "^14.14.34",
         "@types/react-dom": "^18.0.6",
+        "@types/winreg": "^1.2.32",
         "babel-loader": "^8.2.5",
         "builder-util-runtime": "^8.7.3",
         "cross-env": "^7.0.3",
@@ -63,6 +63,7 @@
         "stylelint-config-xo": "^0.20.0",
         "type-fest": "^0.21.3",
         "typescript": "^4.2.3",
+        "winreg": "^1.2.4",
         "write-json-file": "^4.3.0",
         "xo": "^0.38.2"
       }
@@ -8533,6 +8534,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@types/winreg": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@types/winreg/-/winreg-1.2.32.tgz",
+      "integrity": "sha512-+TgocDdajdQVGVDw0XxaOH2rn2YTb8zHqDKdcqj9bHiE0NZaU1KL9StdApF74bNvMx+itYabv9NT6E/iB94N/A==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.16.1",
@@ -29465,7 +29472,8 @@
     "node_modules/winreg": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
-      "integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA=="
+      "integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA==",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -36295,6 +36303,12 @@
           "dev": true
         }
       }
+    },
+    "@types/winreg": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@types/winreg/-/winreg-1.2.32.tgz",
+      "integrity": "sha512-+TgocDdajdQVGVDw0XxaOH2rn2YTb8zHqDKdcqj9bHiE0NZaU1KL9StdApF74bNvMx+itYabv9NT6E/iB94N/A==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.16.1",
@@ -52616,7 +52630,8 @@
     "winreg": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
-      "integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA=="
+      "integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA==",
+      "dev": true
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "stylelint-config-xo": "^0.20.0",
     "type-fest": "^0.21.3",
     "typescript": "^4.2.3",
+    "winreg": "^1.2.4",
     "write-json-file": "^4.3.0",
     "xo": "^0.38.2"
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^14.14.34",
     "@types/react-dom": "^18.0.6",
+    "@types/winreg": "^1.2.32",
     "babel-loader": "^8.2.5",
     "builder-util-runtime": "^8.7.3",
     "cross-env": "^7.0.3",

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -35,12 +35,18 @@ export async function initApp() {
     app.disableHardwareAcceleration()
   }
 
-  app.on('second-instance', () => {
+  app.on('second-instance', (_event, argv, _workingDirectory) => {
+    const mailtoString = argv.find((s) => s.startsWith('mailto:'))
+
+    if (mailtoString) {
+      sendToSelectedAccountView('gmail:compose-mail', mailtoString)
+    }
+
     showMainWindow()
   })
 
   app.on('open-url', (_event, mailto) => {
-    sendToSelectedAccountView('gmail:compose-mail', mailto.split(':')[1])
+    sendToSelectedAccountView('gmail:compose-mail', mailto)
 
     showMainWindow()
   })


### PR DESCRIPTION
This should resolve #206 and #347

added handling of mailto: links with a subject, to, cc, bcc, ad body fields

    currently only handles a single recipient for each of to, cc, bcc

added installing registry keys for registering a mailto: default protocol handler

    this currently needs a manual selection of default Gmail-Desktop as default

